### PR TITLE
尝试使用 xmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@
 */_Generate/*
 
 *.meta
+
+.vscode
+.xmake/
+build/

--- a/Source/External/xmake.lua
+++ b/Source/External/xmake.lua
@@ -1,0 +1,60 @@
+add_requires("assimp")
+add_requires("cereal")
+-- add_requires("directxshadercompiler")
+add_requires("glfw")
+add_requires("glm")
+-- add_requires("glslang")
+-- add_requires("imgui")
+-- add_requires("nativefiledialog")
+add_requires("spdlog")
+-- add_requires("spirv-cross")
+-- add_requires("spirv-reflect")
+add_requires("stb")
+-- add_requires("volk")
+-- add_requires("vulkan-memory-allocator")
+
+add_requires("meshoptimizer")
+add_requires("mustache")
+add_requires("slang")
+
+package("meshoptimizer")
+    on_load(function (package)
+        package:set("installdir", path.join(os.scriptdir(), "meshoptimizer"))
+    end)
+
+    on_fetch(function (package)
+        package:addenv("PATH", package:installdir("bin"))
+
+        local result = {}
+        result.links = "meshoptimizer"
+        result.linkdirs = package:installdir("lib")
+        result.includedirs = package:installdir("include")
+        return result
+    end)
+package_end()
+
+package("mustache")
+    on_load(function (package)
+        package:set("installdir", path.join(os.scriptdir(), "mustache"))
+    end)
+
+    on_fetch(function (package)
+        local result = {}
+        result.includedirs = package:installdir()
+        return result
+    end)
+package_end()
+
+package("slang")
+    on_load(function (package)
+        package:set("installdir", path.join(os.scriptdir(), "slang"))
+    end)
+
+    on_fetch(function (package)
+        package:addenv("PATH", package:installdir("bin/windows-x64/release"))
+
+        local result = {}
+        result.includedirs = package:installdir()
+        return result
+    end)
+package_end()

--- a/Source/Runtime/Core/xmake.lua
+++ b/Source/Runtime/Core/xmake.lua
@@ -1,0 +1,10 @@
+target("Core")
+    set_kind("$(kind)")
+    add_files("Private/*.cpp")
+    set_pcxxheader("Public/Core/Precompile.hpp")
+
+    add_includedirs("Public/Core")
+    add_includedirs("Public", {public  = true})
+
+    add_packages("glfw", "spdlog", "glm", "cereal", "stb")
+target_end()

--- a/Source/Runtime/Geometry/xmake.lua
+++ b/Source/Runtime/Geometry/xmake.lua
@@ -1,0 +1,11 @@
+target("Geometry")
+    set_kind("$(kind)")
+    add_files("Private/**.cpp")
+    set_pcxxheader("Public/Geometry/Precompile.hpp")
+
+    add_includedirs("Public/Geometry")
+    add_includedirs("Public", {public  = true})
+
+    add_deps("Core")
+    add_packages("spdlog", "glm", "cereal")
+target_end()

--- a/Source/Runtime/xmake.lua
+++ b/Source/Runtime/xmake.lua
@@ -1,0 +1,6 @@
+includes("Core")
+-- includes("RHI")
+includes("Geometry")
+-- includes("Render")
+-- includes("Resource")
+-- includes("Scene")

--- a/Source/xmake.lua
+++ b/Source/xmake.lua
@@ -1,0 +1,7 @@
+includes("External")
+includes("Runtime")
+-- includes("Editor")
+-- includes("Engine")
+-- includes("Shaders")
+-- includes("Plugin")
+-- includes("Test")

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,17 @@
+set_project("Ilum")
+set_version("0.0.1")
+
+set_xmakever("2.7.5")
+
+set_warnings("all")
+set_languages("c++17")
+
+add_rules("mode.debug", "mode.release")
+
+set_runtimes("MD")
+add_defines("NOMINMAX")
+set_warnings("all")
+-- set_warnings("all", "error")
+-- add_cxxflags("/permissive", "/WX", {tools = "cl"})
+
+includes("Source")


### PR DESCRIPTION
编译了 runtime 模块里两个 target 做参考

# 一些要点

- 一些全局配置可以写在根目录的 xmake.lua，也可也细粒度一点，根据 target 加
- 添加子目录和 cmake 一样
- xmake-repo 没有的包，我手动打包了（只有3个包需要手动打包，其他都可以扔出去仓库了）
- windows 下开发可以使用动态库 -> `set_runtimes`，加速链接，减小二进制
- `{public  = true}`看着用，interface/public 概念是 build system 都有的
- 可以把子模块都编译成动态库，加速链接 -> [参考](https://zhuanlan.zhihu.com/p/596605872)
- 上面文章中的**使用规则**，你可以参考一下，如果 target 中有重复配置，可以考虑塞进一个 rules 里，比较方便

# 编译
```sh
# -m 设置编译模式，-y 自动安装依赖无需确认
xmake f -m release -y
xmake
```